### PR TITLE
Configure Vercel output and add lint dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
     "react-dom": "18.3.1"
   },
   "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.61",
     "autoprefixer": "10.4.17",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
     "postcss": "8.4.35",
     "tailwindcss": "3.4.3",
-    "typescript": "5.3.3",
-    "@types/react": "18.2.61",
-    "@types/node": "20.12.7"
+    "typescript": "5.3.3"
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
## Summary
- set Vercel's output directory to .next so the build artifact matches Next.js defaults
- add the missing ESLint packages that the Next.js build step expects

## Testing
- ❌ `npm run build` *(blocked by repeated 403 errors when downloading npm packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5532eba508320be58a058394683dd