### PR TITLE
Remove incorrect Vercel outputDirectory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,0 @@
-{
-  "outputDirectory": ".next"
-}


### PR DESCRIPTION
## Summary
- delete the custom vercel.json so Vercel uses the default Next.js deployment settings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d556e44c848320a1b019b02c03b0f9