### PR TITLE
Configure Vercel output directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "framework": "nextjs",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
## Summary
- add a Vercel configuration file that explicitly sets the framework to Next.js
- configure the build command and output directory so Vercel can locate the compiled .next folder after builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d557d16e708320b7d92d1d918e21e7