### PR TITLE
Animate detail reveal and weekly grid

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,3 +5,36 @@
 body {
   @apply antialiased;
 }
+
+.life-fade-section {
+  opacity: 0;
+  transform: translateY(24px);
+  animation: lifeFadeIn 1s ease forwards;
+}
+
+@keyframes lifeFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.life-week {
+  border: 1px solid transparent;
+  transition: background-color 0.45s ease, border-color 0.45s ease, box-shadow 0.45s ease;
+}
+
+.life-week--filled {
+  background-color: #059669;
+  border-color: #059669;
+  box-shadow: 0 6px 14px rgba(5, 150, 105, 0.18), 0 0 8px rgba(16, 185, 129, 0.35);
+}
+
+.life-week--empty {
+  background-color: #e2e8f0;
+  border-color: #cbd5f5;
+}


### PR DESCRIPTION
## Summary
- delay the analytics sections until the user interacts with the birth date and animate their entrance for extra drama
- animate the life-week grid by interpolating the revealed squares and easing the progress bar fill
- add supporting CSS helpers for fade-in sections and smooth square state transitions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d55a260e788320a62b5f6057d33f06