### PR TITLE
Fix LifeClock detail and weeks section refs

### DIFF
--- a/app/LifeClockApp.tsx
+++ b/app/LifeClockApp.tsx
@@ -191,6 +191,7 @@ export default function LifeClockApp() {
   const [visibleWeeks, setVisibleWeeks] = useState(0)
   const visibleWeeksRef = useRef(0)
   const detailsSectionRef = useRef<HTMLDivElement | null>(null)
+  const weeksSectionRef = useRef<HTMLDivElement | null>(null)
   const autoFocusTriggeredRef = useRef(false)
 
   useEffect(() => {
@@ -257,7 +258,18 @@ export default function LifeClockApp() {
 
   useEffect(() => {
     if (!showDetails) return
+    visibleWeeksRef.current = 0
     setVisibleWeeks(0)
+  }, [showDetails, dobStr, expYears])
+
+  useEffect(() => {
+    if (!showDetails) return
+    const el = weeksSectionRef.current
+    if (!el) return
+    const prefersReducedMotion = typeof window !== 'undefined'
+      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      : false
+    el.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'center' })
   }, [showDetails, dobStr, expYears])
 
   useEffect(() => {
@@ -456,7 +468,11 @@ export default function LifeClockApp() {
             </section>
 
             {/* Týždne života (vizualizácia) */}
-            <section className="bg-white rounded-2xl shadow p-6 mb-6 life-fade-section" style={{ animationDelay: '300ms' }}>
+            <section
+              ref={weeksSectionRef}
+              className="bg-white rounded-2xl shadow p-6 mb-6 life-fade-section"
+              style={{ animationDelay: '300ms' }}
+            >
               <div className="flex items-center justify-between mb-4">
                 <div>
                   <div className="text-sm text-slate-600">Týždne života</div>


### PR DESCRIPTION
## Summary
- restore the weeks section ref while keeping the details focus ref
- reset the week animation state whenever details are shown and scroll the weeks section into view

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d569300dc08320b44d54a61ec63c64