### PR TITLE
Refine onboarding flow and add dark mode

### DIFF
--- a/app/LifeClockApp.tsx
+++ b/app/LifeClockApp.tsx
@@ -111,16 +111,25 @@ function runSelfTests() {
   }
 }
 
-// ===== Component =====
-export default function LifeClockApp() {
-  // DOB string used by compute; derive from year/month/day
-  const [dobStr, setDobStr] = useState<string>('')
+type Step = 'year' | 'month' | 'day' | 'prep' | 'visual'
 
-  // UX-friendly DOB picker (Year / Month / Day)
+export default function LifeClockApp() {
+  const [isDarkMode, setIsDarkMode] = useState(false)
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const root = document.documentElement
+    root.classList.toggle('dark', isDarkMode)
+    return () => {
+      root.classList.remove('dark')
+    }
+  }, [isDarkMode])
+
   const [dobYear, setDobYear] = useState<number>(1999)
   const [dobMonth, setDobMonth] = useState<number>(1)
   const [dobDay, setDobDay] = useState<number>(1)
+  const [dobStr, setDobStr] = useState<string>('')
   const [expYears, setExpYears] = useState<number>(82)
+
   const years = useMemo(() => {
     const out: number[] = []
     const current = new Date().getFullYear()
@@ -130,106 +139,69 @@ export default function LifeClockApp() {
   const months = useMemo(() => Array.from({ length: 12 }, (_, i) => i + 1), [])
   const daysInMonth = (y: number, m: number) => new Date(y, m, 0).getDate()
 
-  // Keep dobStr in sync with individual Y/M/D selects
   useEffect(() => {
     const maxDay = daysInMonth(dobYear, dobMonth)
     const safeDay = Math.min(dobDay, maxDay)
-    if (safeDay !== dobDay) setDobDay(safeDay)
+    if (safeDay !== dobDay) {
+      setDobDay(safeDay)
+      return
+    }
     const mm = String(dobMonth).padStart(2, '0')
     const dd = String(safeDay).padStart(2, '0')
     const nextDob = `${dobYear}-${mm}-${dd}`
-    if (nextDob !== dobStr) {
-      setDobStr(nextDob)
-    }
-  }, [dobYear, dobMonth, dobDay, dobStr])
+    setDobStr(prev => (prev === nextDob ? prev : nextDob))
+  }, [dobYear, dobMonth, dobDay])
 
-  // Hydrate from URL params (if available) and run self-tests once on mount
   useEffect(() => {
-    const applyDobFromParam = (value: string) => {
-      const parts = value.split('-')
-      if (parts.length !== 3) return
-      const [yearStr, monthStr, dayStr] = parts
-      const year = Number(yearStr)
-      const month = Number(monthStr)
-      const day = Number(dayStr)
-      if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) return
-      const currentYear = new Date().getFullYear()
-      const safeYear = clamp(year, 1900, currentYear)
-      const safeMonth = clamp(month, 1, 12)
-      const safeDay = clamp(day, 1, daysInMonth(safeYear, safeMonth))
-      const mm = String(safeMonth).padStart(2, '0')
-      const dd = String(safeDay).padStart(2, '0')
-      const nextDob = `${safeYear}-${mm}-${dd}`
-      setDobYear(safeYear)
-      setDobMonth(safeMonth)
-      setDobDay(safeDay)
-      setDobStr(nextDob)
-      setHasInteractedWithDob(true)
-    }
-
-    if (typeof window !== 'undefined') {
-      const params = new URLSearchParams(window.location.search)
-      const dobParam = params.get('dob')
-      if (dobParam) {
-        applyDobFromParam(dobParam)
-      }
-      const expParam = params.get('exp')
-      if (expParam) {
-        const parsed = Number(expParam)
-        if (!Number.isNaN(parsed)) {
-          setExpYears(clamp(parsed, 30, 120))
-        }
-      }
-    }
-
     runSelfTests()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const [hasInteractedWithDob, setHasInteractedWithDob] = useState(false)
-  const [showDetails, setShowDetails] = useState(false)
-  const [visibleWeeks, setVisibleWeeks] = useState(0)
-  const visibleWeeksRef = useRef(0)
-  const detailsSectionRef = useRef<HTMLDivElement | null>(null)
-  const weeksSectionRef = useRef<HTMLDivElement | null>(null)
-  const autoFocusTriggeredRef = useRef(false)
+  const [currentStep, setCurrentStep] = useState<Step>('year')
+  const [isLeaving, setIsLeaving] = useState(false)
+  const [nextStep, setNextStep] = useState<Step | null>(null)
+  const [enterPhase, setEnterPhase] = useState(false)
+
+  const goToStep = useCallback((step: Step) => {
+    if (step === currentStep || isLeaving) return
+    setNextStep(step)
+    setIsLeaving(true)
+  }, [currentStep, isLeaving])
 
   useEffect(() => {
-    visibleWeeksRef.current = visibleWeeks
-  }, [visibleWeeks])
+    if (!isLeaving) return
+    const timer = window.setTimeout(() => {
+      if (nextStep) {
+        setCurrentStep(nextStep)
+        setNextStep(null)
+      }
+      setIsLeaving(false)
+    }, 700)
+    return () => window.clearTimeout(timer)
+  }, [isLeaving, nextStep])
 
   useEffect(() => {
-    if (showDetails) {
-      autoFocusTriggeredRef.current = false
+    if (isLeaving) return
+    const timer = window.setTimeout(() => setEnterPhase(false), 40)
+    setEnterPhase(true)
+    return () => window.clearTimeout(timer)
+  }, [currentStep, isLeaving])
+
+  const [prepPhase, setPrepPhase] = useState<'hidden' | 'in' | 'out'>('hidden')
+  useEffect(() => {
+    if (currentStep !== 'prep') {
+      setPrepPhase('hidden')
+      return
     }
-  }, [dobStr, expYears, showDetails])
-
-  const markDobInteraction = () => {
-    setHasInteractedWithDob(true)
-  }
-
-  useEffect(() => {
-    if (!showDetails || autoFocusTriggeredRef.current) return
-    if (typeof window === 'undefined') return
-    const el = detailsSectionRef.current
-    if (!el) return
-    const isSmallScreen = window.matchMedia('(max-width: 767px)').matches
-    if (!isSmallScreen) return
-
-    autoFocusTriggeredRef.current = true
-    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    const behavior: ScrollBehavior = prefersReducedMotion ? 'auto' : 'smooth'
-    el.scrollIntoView({ behavior, block: 'start' })
-    if (el instanceof HTMLElement) {
-      el.focus({ preventScroll: true })
+    setPrepPhase('in')
+    const fadeOutTimer = window.setTimeout(() => setPrepPhase('out'), 2200)
+    const proceedTimer = window.setTimeout(() => {
+      goToStep('visual')
+    }, 4400)
+    return () => {
+      window.clearTimeout(fadeOutTimer)
+      window.clearTimeout(proceedTimer)
     }
-  }, [showDetails, dobStr, expYears])
-
-  useEffect(() => {
-    if (!hasInteractedWithDob || !dobStr) return
-    const timeout = window.setTimeout(() => setShowDetails(true), 200)
-    return () => window.clearTimeout(timeout)
-  }, [hasInteractedWithDob, dobStr])
+  }, [currentStep, goToStep])
 
   // Live time ticker
   const [now, setNow] = useState<Date>(() => new Date())
@@ -245,7 +217,6 @@ export default function LifeClockApp() {
     }
   }, [])
 
-  // Derived stats
   const stats: LifeStats | null = useMemo(() => {
     if (!dobStr) return null
     const dobDate = new Date(dobStr)
@@ -253,253 +224,330 @@ export default function LifeClockApp() {
     return computeLifeStats(dobDate, now, expYears)
   }, [dobStr, now, expYears])
 
+  const showDetails = currentStep === 'visual' && !!stats
+
+  const [visibleWeeks, setVisibleWeeks] = useState(0)
+  const visibleWeeksRef = useRef(0)
+  const [weeksAnimationDone, setWeeksAnimationDone] = useState(false)
+  const hasStats = Boolean(stats)
   const totalWeeks = stats?.totalWeeks ?? 0
-  const targetWeeks = stats ? clamp(stats.livedWeeks, 0, totalWeeks) : 0
+  const livedWeeks = stats?.livedWeeks ?? 0
 
   useEffect(() => {
-    if (!showDetails) return
+    visibleWeeksRef.current = visibleWeeks
+  }, [visibleWeeks])
+
+  useEffect(() => {
+    if (!showDetails || !hasStats) {
+      setVisibleWeeks(0)
+      setWeeksAnimationDone(false)
+      return
+    }
     visibleWeeksRef.current = 0
     setVisibleWeeks(0)
-  }, [showDetails, dobStr, expYears])
+    setWeeksAnimationDone(false)
+  }, [showDetails, hasStats, totalWeeks, livedWeeks])
 
   useEffect(() => {
-    if (!showDetails) return
-    const el = weeksSectionRef.current
-    if (!el) return
+    if (!showDetails || !hasStats) return
+    const target = clamp(livedWeeks, 0, totalWeeks)
+    if (totalWeeks <= 0 || target <= 0) {
+      setVisibleWeeks(target)
+      setWeeksAnimationDone(true)
+      return
+    }
+
     const prefersReducedMotion = typeof window !== 'undefined'
       ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
       : false
-    el.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'center' })
-  }, [showDetails, dobStr, expYears])
 
-  useEffect(() => {
-    if (!showDetails || totalWeeks <= 0) return
-    const target = targetWeeks
-    const startValue = clamp(visibleWeeksRef.current, 0, totalWeeks)
-    if (target === startValue) return
+    if (prefersReducedMotion) {
+      setVisibleWeeks(target)
+      setWeeksAnimationDone(true)
+      return
+    }
 
-    const duration = Math.min(4000, Math.max(1200, totalWeeks * 6))
     let startTime: number | null = null
     let raf: number
+    const duration = Math.max(6000, target * 18)
 
     const step = (timestamp: number) => {
       if (startTime === null) startTime = timestamp
       const progress = Math.min(1, (timestamp - startTime) / duration)
-      const interpolated = Math.round(startValue + (target - startValue) * progress)
-      if (progress >= 1) {
-        setVisibleWeeks(target)
-      } else {
-        setVisibleWeeks(interpolated)
-      }
+      const interpolated = Math.round(target * progress)
+      setVisibleWeeks(interpolated)
       if (progress < 1) {
         raf = requestAnimationFrame(step)
+      } else {
+        setVisibleWeeks(target)
+        setWeeksAnimationDone(true)
       }
     }
 
     raf = requestAnimationFrame(step)
     return () => cancelAnimationFrame(raf)
-  }, [showDetails, targetWeeks, totalWeeks])
+  }, [showDetails, hasStats, totalWeeks, livedWeeks])
 
-  // Share URL (embeds dob & expectancy)
-  const shareUrl = () => {
-    if (typeof window === 'undefined') return
-    const p = new URLSearchParams()
-    if (dobStr) p.set('dob', dobStr)
-    if (expYears) p.set('exp', String(expYears))
-    const query = p.toString()
-    const base = `${window.location.origin}${window.location.pathname}`
-    const url = query ? `${base}?${query}` : base
-    if (navigator?.clipboard?.writeText) {
-      navigator.clipboard.writeText(url).then(() => {
-        alert('URL skopírované do schránky.')
-      }).catch(() => {
-        prompt('Skopíruj túto URL:', url)
-      })
-    } else {
-      prompt('Skopíruj túto URL:', url)
-    }
-    if (window.history?.replaceState) {
-      window.history.replaceState({}, '', url)
+  const displayedLivedWeeks = showDetails ? Math.min(visibleWeeks, totalWeeks) : 0
+  const progressWidth = showDetails && stats ? `${stats.percent}%` : '0%'
+
+  const fmtInt = (n: number | undefined) => (typeof n === 'number' ? n.toLocaleString('sk-SK') : '—')
+  const fmtPct = (n: number | undefined) => (typeof n === 'number' ? `${n.toFixed(2)}%` : '—')
+
+  const toggleDarkMode = () => setIsDarkMode(v => !v)
+
+  const stepCardBase = currentStep === 'visual'
+    ? 'w-full max-w-4xl rounded-[36px] bg-white/70 p-8 shadow-2xl backdrop-blur-xl dark:bg-slate-900/60 sm:p-10'
+    : 'w-full max-w-xl rounded-[32px] bg-white/75 p-8 shadow-2xl backdrop-blur-xl dark:bg-slate-900/60 sm:p-10'
+
+  const stepCardState = isLeaving
+    ? 'opacity-0 translate-y-12 pointer-events-none'
+    : enterPhase
+      ? 'opacity-0 translate-y-8'
+      : 'opacity-100 translate-y-0'
+
+  const renderStep = (step: Step) => {
+    const formattedDob = dobStr ? new Date(dobStr).toLocaleDateString('sk-SK') : '—'
+    switch (step) {
+      case 'year':
+        return (
+          <div className="flex flex-col items-center gap-6 text-center">
+            <span className="text-sm font-semibold uppercase tracking-[0.45em] text-emerald-600 dark:text-emerald-300/90">Krok 1</span>
+            <h2 className="text-3xl font-semibold sm:text-4xl">Zadaj rok narodenia</h2>
+            <p className="max-w-sm text-sm text-slate-600 dark:text-slate-300">
+              Začni rokom, aby sme vedeli, kde na časovej osi života sa nachádzaš.
+            </p>
+            <select
+              value={dobYear}
+              onChange={(e) => setDobYear(Number(e.target.value))}
+              className="w-52 rounded-2xl border border-emerald-300/40 bg-white/80 px-4 py-3 text-lg font-semibold shadow-inner transition-all duration-500 hover:border-emerald-400 focus:border-emerald-500 focus:outline-none dark:border-emerald-400/30 dark:bg-slate-900/70"
+            >
+              {years.map((y) => (
+                <option key={y} value={y}>{y}</option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={() => goToStep('month')}
+              className="rounded-full bg-emerald-500 px-8 py-3 text-base font-semibold text-white shadow-lg transition-all duration-500 hover:bg-emerald-400 hover:shadow-xl"
+            >
+              Pokračovať
+            </button>
+          </div>
+        )
+      case 'month':
+        return (
+          <div className="flex flex-col items-center gap-6 text-center">
+            <span className="text-sm font-semibold uppercase tracking-[0.45em] text-emerald-600 dark:text-emerald-300/90">Krok 2</span>
+            <h2 className="text-3xl font-semibold sm:text-4xl">Vyber mesiac</h2>
+            <p className="max-w-sm text-sm text-slate-600 dark:text-slate-300">
+              Mesiac narodenia doladí presnosť výpočtu každého zeleného bodu.
+            </p>
+            <select
+              value={dobMonth}
+              onChange={(e) => setDobMonth(Number(e.target.value))}
+              className="w-52 rounded-2xl border border-emerald-300/40 bg-white/80 px-4 py-3 text-lg font-semibold shadow-inner transition-all duration-500 hover:border-emerald-400 focus:border-emerald-500 focus:outline-none dark:border-emerald-400/30 dark:bg-slate-900/70"
+            >
+              {months.map((m) => (
+                <option key={m} value={m}>{String(m).padStart(2, '0')}</option>
+              ))}
+            </select>
+            <div className="flex flex-col gap-3 sm:flex-row sm:gap-4">
+              <button
+                type="button"
+                onClick={() => goToStep('year')}
+                className="rounded-full border border-emerald-400/60 px-6 py-2 text-sm font-semibold text-emerald-600 transition-all duration-500 hover:border-emerald-500 hover:text-emerald-500 dark:border-emerald-300/60 dark:text-emerald-200"
+              >
+                Späť
+              </button>
+              <button
+                type="button"
+                onClick={() => goToStep('day')}
+                className="rounded-full bg-emerald-500 px-8 py-3 text-base font-semibold text-white shadow-lg transition-all duration-500 hover:bg-emerald-400 hover:shadow-xl"
+              >
+                Pokračovať
+              </button>
+            </div>
+          </div>
+        )
+      case 'day':
+        return (
+          <div className="flex flex-col items-center gap-6 text-center">
+            <span className="text-sm font-semibold uppercase tracking-[0.45em] text-emerald-600 dark:text-emerald-300/90">Krok 3</span>
+            <h2 className="text-3xl font-semibold sm:text-4xl">A teraz deň</h2>
+            <p className="max-w-sm text-sm text-slate-600 dark:text-slate-300">
+              {`Dátum zatiaľ: ${formattedDob}`}
+            </p>
+            <select
+              value={dobDay}
+              onChange={(e) => setDobDay(Number(e.target.value))}
+              className="w-52 rounded-2xl border border-emerald-300/40 bg-white/80 px-4 py-3 text-lg font-semibold shadow-inner transition-all duration-500 hover:border-emerald-400 focus:border-emerald-500 focus:outline-none dark:border-emerald-400/30 dark:bg-slate-900/70"
+            >
+              {Array.from({ length: daysInMonth(dobYear, dobMonth) }, (_, i) => i + 1).map((d) => (
+                <option key={d} value={d}>{String(d).padStart(2, '0')}</option>
+              ))}
+            </select>
+            <div className="flex flex-col gap-3 sm:flex-row sm:gap-4">
+              <button
+                type="button"
+                onClick={() => goToStep('month')}
+                className="rounded-full border border-emerald-400/60 px-6 py-2 text-sm font-semibold text-emerald-600 transition-all duration-500 hover:border-emerald-500 hover:text-emerald-500 dark:border-emerald-300/60 dark:text-emerald-200"
+              >
+                Späť
+              </button>
+              <button
+                type="button"
+                onClick={() => goToStep('prep')}
+                className="rounded-full bg-emerald-500 px-8 py-3 text-base font-semibold text-white shadow-lg transition-all duration-500 hover:bg-emerald-400 hover:shadow-xl"
+              >
+                Spustiť vizualizáciu
+              </button>
+            </div>
+          </div>
+        )
+      case 'prep':
+        return (
+          <div className="flex min-h-[200px] flex-col items-center justify-center gap-4 text-center">
+            <span
+              className={`text-4xl font-semibold uppercase tracking-[0.65em] text-emerald-600 transition-opacity duration-[2200ms] ease-out dark:text-emerald-300 ${prepPhase === 'in' ? 'opacity-100' : 'opacity-0'}`}
+            >
+              Priprav sa
+            </span>
+            <p
+              className={`text-sm text-slate-600 transition-opacity duration-[2200ms] ease-out dark:text-slate-300 ${prepPhase === 'out' ? 'opacity-0' : 'opacity-100'}`}
+            >
+              Zelené bodky sa prebúdzajú a plnia jeden týždeň po druhom.
+            </p>
+          </div>
+        )
+      case 'visual':
+        return (
+          <div className="flex w-full flex-col items-center gap-8 text-center">
+            <div className="flex flex-col items-center gap-3">
+              <span className="text-xs font-semibold uppercase tracking-[0.6em] text-emerald-500 dark:text-emerald-300/80">Život na jednej obrazovke</span>
+              <h2 className="text-3xl font-semibold sm:text-4xl">Tvoje zelené týždne</h2>
+              <p className="text-sm text-slate-600 dark:text-slate-300">
+                {dobStr ? `Narodený ${formattedDob} • očakávanie ${expYears.toFixed(0)} rokov` : 'Zadaj dátum a sleduj vizualizáciu života.'}
+              </p>
+              <button
+                type="button"
+                onClick={() => goToStep('year')}
+                className="text-sm font-semibold text-emerald-600 transition-colors duration-500 hover:text-emerald-500 dark:text-emerald-300"
+              >
+                Zmeniť dátum
+              </button>
+            </div>
+
+            <div className={`w-full max-w-4xl transition-opacity duration-[1800ms] ease-out ${showDetails ? 'opacity-100' : 'opacity-0'}`}>
+              <div className="flex flex-col items-center gap-6">
+                <div className="h-3 w-full overflow-hidden rounded-full bg-emerald-100/50 dark:bg-emerald-500/20">
+                  <div className="h-3 rounded-full bg-emerald-500 transition-all duration-[2600ms] ease-out dark:bg-emerald-400" style={{ width: progressWidth }} />
+                </div>
+                <div className="w-full rounded-[28px] border border-emerald-500/15 bg-white/60 p-6 shadow-inner backdrop-blur-sm dark:border-emerald-400/20 dark:bg-slate-900/50">
+                  <div className="grid" style={{ gridTemplateColumns: 'repeat(52, minmax(0,1fr))', gap: 2 }}>
+                    {stats && Array.from({ length: stats.totalWeeks }).map((_, i) => (
+                      <div
+                        key={i}
+                        className={`life-week w-full rounded-[3px] ${i < displayedLivedWeeks ? 'life-week--filled' : 'life-week--empty'}`}
+                        style={{ paddingTop: '100%' }}
+                      />
+                    ))}
+                  </div>
+                </div>
+                <p className="text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Každý štvorček = 1 týždeň života</p>
+              </div>
+            </div>
+
+            <div className={`w-full max-w-4xl transition-all duration-[1600ms] ease-out ${weeksAnimationDone ? 'opacity-100 translate-y-0' : 'pointer-events-none opacity-0 translate-y-8'}`}>
+              <div className="flex flex-col gap-6 rounded-[32px] border border-emerald-500/15 bg-white/70 p-6 shadow-2xl backdrop-blur-xl dark:border-emerald-400/15 dark:bg-slate-900/60 sm:p-8">
+                <div className="flex flex-col gap-3 text-left sm:flex-row sm:items-center sm:justify-between">
+                  <label className="text-sm font-medium text-slate-600 dark:text-slate-300">
+                    Očakávaná dĺžka života:
+                    {' '}
+                    <span className="font-semibold text-emerald-600 dark:text-emerald-300">{expYears.toFixed(0)} rokov</span>
+                  </label>
+                  <input
+                    type="range"
+                    min={30}
+                    max={120}
+                    step={1}
+                    value={expYears}
+                    onChange={(e) => setExpYears(clamp(Number(e.target.value), 30, 120))}
+                    className="h-2 w-full max-w-sm cursor-pointer appearance-none rounded-full bg-emerald-200/60 accent-emerald-500 dark:bg-emerald-500/30"
+                  />
+                </div>
+
+                <div className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2 lg:grid-cols-4">
+                  <div className="rounded-2xl bg-emerald-500/10 p-4 shadow-inner dark:bg-emerald-500/15">
+                    <div className="text-xs uppercase tracking-[0.3em] text-emerald-700 dark:text-emerald-200">Vek</div>
+                    <div className="mt-2 text-2xl font-semibold tabular-nums">
+                      {stats ? `${stats.ageYears.toFixed(2)} r` : '—'}
+                    </div>
+                  </div>
+                  <div className="rounded-2xl bg-emerald-500/10 p-4 shadow-inner dark:bg-emerald-500/15">
+                    <div className="text-xs uppercase tracking-[0.3em] text-emerald-700 dark:text-emerald-200">Zostáva</div>
+                    <div className="mt-2 text-2xl font-semibold tabular-nums">
+                      {stats ? `${stats.leftYears.toFixed(2)} r` : '—'}
+                    </div>
+                  </div>
+                  <div className="rounded-2xl bg-emerald-500/10 p-4 shadow-inner dark:bg-emerald-500/15">
+                    <div className="text-xs uppercase tracking-[0.3em] text-emerald-700 dark:text-emerald-200">% prežité</div>
+                    <div className="mt-2 text-2xl font-semibold tabular-nums">
+                      {stats ? fmtPct(stats.percent) : '—'}
+                    </div>
+                  </div>
+                  <div className="rounded-2xl bg-emerald-500/10 p-4 shadow-inner dark:bg-emerald-500/15">
+                    <div className="text-xs uppercase tracking-[0.3em] text-emerald-700 dark:text-emerald-200">Live odpočítavanie</div>
+                    <div className="mt-2 text-base font-semibold tabular-nums">
+                      {stats
+                        ? `${Math.floor(stats.leftYears)}r ${stats.leftParts.days % 365}d ${stats.leftParts.hours}h ${stats.leftParts.minutes}m ${stats.leftParts.seconds}s`
+                        : '—'}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-3 text-sm text-slate-600 dark:text-slate-300">
+                  <p>
+                    Prežité týždne:{' '}
+                    <strong>{stats ? fmtInt(stats.livedWeeks) : '—'} / {stats ? fmtInt(stats.totalWeeks) : '—'}</strong>
+                  </p>
+                  <p>
+                    Zelené bodky reprezentujú každý týždeň života. Sleduj, ako sa plnia – pomaly, vytrvalo a na jednom mieste.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        )
+      default:
+        return null
     }
   }
 
-  // Formatting helpers
-  const fmtInt = (n: number | undefined) =>
-    typeof n === 'number' ? n.toLocaleString('sk-SK') : '—'
-  const fmtPct = (n: number | undefined) =>
-    typeof n === 'number' ? `${n.toFixed(2)}%` : '—'
-
-  const progressWidth = showDetails && stats ? `${stats.percent}%` : '0%'
-  const displayedLivedWeeks = showDetails ? clamp(visibleWeeks, 0, totalWeeks) : 0
-
-  const reanimateWeeks = useCallback(() => {
-    if (!showDetails || !stats) return
-    const target = clamp(stats.livedWeeks, 0, stats.totalWeeks)
-    setVisibleWeeks(0)
-    visibleWeeksRef.current = 0
-    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
-      window.requestAnimationFrame(() => {
-        setVisibleWeeks(target)
-      })
-    } else {
-      setVisibleWeeks(target)
-    }
-  }, [showDetails, stats])
-
   return (
-    <div className="min-h-screen w-full bg-slate-50 text-slate-900 p-6 md:p-10">
-      <div className="max-w-5xl mx-auto">
-        <header className="mb-6">
-          <h1 className="text-3xl md:text-4xl font-bold tracking-tight">Life Clock – Koľko času Ti ostáva?</h1>
-          <p className="text-slate-600 mt-2">Zadaj dátum narodenia a očakávanú dĺžku života. Appka v reálnom čase zobrazuje <strong>čas prežitý</strong>, <strong>čas zostávajúci</strong>, percentá a vizualizáciu <strong>týždňov života</strong>.</p>
-        </header>
+    <div className={`relative flex h-screen w-full items-center justify-center overflow-hidden bg-slate-100 text-slate-900 transition-colors duration-[1200ms] ease-out ${isDarkMode ? 'dark' : ''} dark:bg-slate-950 dark:text-slate-100`}>
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.18),_transparent_55%)] dark:bg-[radial-gradient(circle_at_top,_rgba(34,197,94,0.2),_transparent_60%)]" />
+      <div className="absolute top-6 right-6 z-20">
+        <button
+          type="button"
+          onClick={toggleDarkMode}
+          className="rounded-full border border-emerald-500/40 bg-white/70 px-5 py-2 text-sm font-semibold text-emerald-600 shadow-lg transition-all duration-500 hover:border-emerald-500 hover:bg-white hover:text-emerald-500 dark:border-emerald-300/50 dark:bg-slate-900/70 dark:text-emerald-200"
+        >
+          {isDarkMode ? 'Svetlý režim' : 'Tmavý režim'}
+        </button>
+      </div>
 
-        <section className="bg-white rounded-2xl shadow p-4 md:p-6 mb-6">
-          <div className="grid md:grid-cols-4 gap-4 items-end">
-            <div>
-              <label className="block text-sm text-slate-600 mb-1">Dátum narodenia</label>
-              <div className="grid grid-cols-3 gap-2">
-                <select aria-label="Rok narodenia" className="rounded-xl border border-slate-200 px-3 py-2 hover:border-slate-300 transition-colors" value={dobYear} onChange={(e) => { markDobInteraction(); setDobYear(Number(e.target.value)); }}>
-                  {years.map((y) => (<option key={y} value={y}>{y}</option>))}
-                </select>
-                <select aria-label="Mesiac" className="rounded-xl border border-slate-200 px-3 py-2 hover:border-slate-300 transition-colors" value={dobMonth} onChange={(e) => { markDobInteraction(); setDobMonth(Number(e.target.value)); }}>
-                  {months.map((m) => (<option key={m} value={m}>{String(m).padStart(2,'0')}</option>))}
-                </select>
-                <select aria-label="Deň" className="rounded-xl border border-slate-200 px-3 py-2 hover:border-slate-300 transition-colors" value={dobDay} onChange={(e) => { markDobInteraction(); setDobDay(Number(e.target.value)); }}>
-                  {Array.from({ length: daysInMonth(dobYear, dobMonth) }, (_, i) => i + 1).map((d) => (<option key={d} value={d}>{String(d).padStart(2,'0')}</option>))}
-                </select>
-              </div>
-              <div className="mt-2 flex flex-wrap gap-2 text-xs text-slate-600">
-                <span>Rýchly skok na rok:</span>
-                {[2000, 1995, 1990, 1985, 1980, 1975].map((y) => (
-                  <button key={y} type="button" className="rounded-lg px-2 py-1 bg-slate-100 hover:bg-slate-200 active:bg-slate-300 transition-colors" onClick={() => { markDobInteraction(); setDobYear(y); }}>{y}</button>
-                ))}
-                <button type="button" className="rounded-lg px-2 py-1 bg-slate-100 hover:bg-slate-200 active:bg-slate-300 transition-colors" onClick={() => { const y = new Date().getFullYear(); markDobInteraction(); setDobYear(y); setDobMonth(1); setDobDay(1); }}>Dnešný rok</button>
-              </div>
-              <p className="text-xs text-slate-500 mt-1">Tip: vyber najprv rok, potom mesiac a deň; dátum ukladáme ako {dobStr || '—'}.</p>
-            </div>
+      <div className="relative z-10 flex h-full w-full max-w-6xl flex-col items-center justify-center gap-8 px-6 text-center">
+        <div className="flex flex-col items-center gap-4">
+          <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">Life Clock</h1>
+          <p className="max-w-xl text-sm text-slate-600 transition-opacity duration-[1200ms] ease-out dark:text-slate-300">
+            Jeden dátum, jedna obrazovka a tiché plnenie zelených bodiek. Sleduj svoj život bez scrollovania, pomaly a sústredene.
+          </p>
+        </div>
 
-            <div>
-              <label className="block text-sm text-slate-600 mb-1">Očakávaná dĺžka života (roky)</label>
-              <input
-                type="number"
-                min={30}
-                max={120}
-                step={0.1}
-                className="w-full rounded-xl border border-slate-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-slate-300 hover:border-slate-300 transition-colors"
-                value={expYears}
-                onChange={(e) => setExpYears(clamp(Number(e.target.value), 30, 120))}
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm text-slate-600 mb-1">Rýchle predvoľby</label>
-              <div className="flex flex-wrap gap-2">
-                {[
-                  { label: 'EU muž ~76', v: 76 },
-                  { label: 'EU žena ~82', v: 82 },
-                  { label: 'Ambiciózne 85', v: 85 },
-                  { label: 'Dlhšie 90', v: 90 },
-                ].map((b) => (
-                  <button
-                    key={b.label}
-                    className="rounded-xl px-3 py-2 bg-slate-100 hover:bg-slate-200 active:bg-slate-300 transition-colors"
-                    onClick={() => {
-                      markDobInteraction()
-                      if (b.v === expYears) {
-                        reanimateWeeks()
-                      } else {
-                        setVisibleWeeks(0)
-                        visibleWeeksRef.current = 0
-                        setExpYears(b.v)
-                      }
-                    }}
-                  >
-                    {b.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <div>
-              <label className="block text-sm text-slate-600 mb-1">Zdieľať nastavenia</label>
-              <button
-                onClick={shareUrl}
-                className="w-full rounded-xl px-3 py-2 bg-emerald-600 text-white hover:bg-emerald-700 active:bg-emerald-800 transition-colors"
-              >Kopírovať URL s nastaveniami</button>
-            </div>
-          </div>
-        </section>
-
-        {showDetails && (
-          <div ref={detailsSectionRef} tabIndex={-1}>
-            <section className="grid md:grid-cols-4 gap-4 mb-6 life-fade-section" style={{ animationDelay: '0ms' }}>
-              <div className="bg-white rounded-2xl shadow p-5">
-                <div className="text-sm text-slate-600">Vek</div>
-                <div className="text-3xl font-bold tabular-nums">{stats ? stats.ageYears.toFixed(2) : '—'}</div>
-              </div>
-              <div className="bg-white rounded-2xl shadow p-5">
-                <div className="text-sm text-slate-600">Zostáva (roky)</div>
-                <div className="text-3xl font-bold tabular-nums">{stats ? stats.leftYears.toFixed(2) : '—'}</div>
-              </div>
-              <div className="bg-white rounded-2xl shadow p-5">
-                <div className="text-sm text-slate-600">% prežité</div>
-                <div className="text-3xl font-bold tabular-nums">{stats ? fmtPct(stats.percent) : '—'}</div>
-              </div>
-              <div className="bg-white rounded-2xl shadow p-5">
-                <div className="text-sm text-slate-600">Live odpočítavanie</div>
-                <div className="text-xl font-semibold tabular-nums">
-                  {stats
-                    ? `${Math.floor(stats.leftYears)}r ${stats.leftParts.days % 365}d ${stats.leftParts.hours}h ${stats.leftParts.minutes}m ${stats.leftParts.seconds}s`
-                    : '—'}
-                </div>
-                <div className="text-xs text-slate-500 mt-1">Roky • dni • hodiny • minúty • sekundy</div>
-              </div>
-            </section>
-
-            <section className="bg-white rounded-2xl shadow p-6 mb-6 life-fade-section" style={{ animationDelay: '150ms' }}>
-              <div className="flex items-center justify-between mb-2">
-                <div className="text-sm text-slate-600">Životný progres</div>
-                <div className="text-sm font-medium">{stats ? `${stats.percent.toFixed(2)}% prežité` : '—'}</div>
-              </div>
-              <div className="w-full h-4 bg-slate-100 rounded-full overflow-hidden">
-                <div className="h-4 bg-emerald-600 transition-all duration-[2000ms] ease-out" style={{ width: progressWidth }} />
-              </div>
-            </section>
-
-            {/* Týždne života (vizualizácia) */}
-            <section
-              ref={weeksSectionRef}
-              className="bg-white rounded-2xl shadow p-6 mb-6 life-fade-section"
-              style={{ animationDelay: '300ms' }}
-            >
-              <div className="flex items-center justify-between mb-4">
-                <div>
-                  <div className="text-sm text-slate-600">Týždne života</div>
-                  <div className="text-xs text-slate-500">Každý štvorček je 1 týždeň. 52 stĺpcov = 1 rok.</div>
-                </div>
-                <div className="text-sm font-medium">
-                  {stats ? `${stats.livedWeeks.toLocaleString('sk-SK')} / ${stats.totalWeeks.toLocaleString('sk-SK')} týždňov` : '—'}
-                </div>
-              </div>
-
-              <div className="grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(52, minmax(0,1fr))', gap: 2 }}>
-                {stats && Array.from({ length: stats.totalWeeks }).map((_, i) => (
-                  <div
-                    key={i}
-                    className={`life-week w-full rounded-[2px] ${i < displayedLivedWeeks ? 'life-week--filled' : 'life-week--empty'}`}
-                    style={{ paddingTop: '100%' }}
-                  />
-                ))}
-              </div>
-
-              <div className="flex items-center gap-3 mt-4 text-xs text-slate-600">
-                <div className="flex items-center gap-1"><span className="inline-block w-3 h-3 rounded-sm bg-emerald-600" /> prežité</div>
-                <div className="flex items-center gap-1"><span className="inline-block w-3 h-3 rounded-sm bg-slate-200 border border-slate-300" /> zostáva</div>
-              </div>
-            </section>
-          </div>
-        )}
+        <div className={`${stepCardBase} transition-all duration-[900ms] ease-out ${stepCardState}`}>
+          {renderStep(currentStep)}
+        </div>
       </div>
     </div>
   )

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,38 +3,36 @@
 @tailwind utilities;
 
 body {
-  @apply antialiased;
+  @apply antialiased bg-slate-100 text-slate-900 transition-colors duration-[1200ms];
 }
 
-.life-fade-section {
-  opacity: 0;
-  transform: translateY(24px);
-  animation: lifeFadeIn 1s ease forwards;
-}
-
-@keyframes lifeFadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(24px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+.dark body {
+  @apply bg-slate-950 text-slate-100;
 }
 
 .life-week {
   border: 1px solid transparent;
-  transition: background-color 0.45s ease, border-color 0.45s ease, box-shadow 0.45s ease;
+  transition: background-color 0.8s ease, border-color 0.8s ease, box-shadow 0.8s ease;
 }
 
 .life-week--filled {
-  background-color: #059669;
-  border-color: #059669;
-  box-shadow: 0 6px 14px rgba(5, 150, 105, 0.18), 0 0 8px rgba(16, 185, 129, 0.35);
+  background-color: #10b981;
+  border-color: #10b981;
+  box-shadow: 0 12px 24px rgba(16, 185, 129, 0.28), 0 0 14px rgba(16, 185, 129, 0.45);
 }
 
 .life-week--empty {
-  background-color: #e2e8f0;
-  border-color: #cbd5f5;
+  background-color: rgba(148, 163, 184, 0.35);
+  border-color: rgba(148, 163, 184, 0.5);
+}
+
+.dark .life-week--filled {
+  background-color: #34d399;
+  border-color: #34d399;
+  box-shadow: 0 12px 26px rgba(52, 211, 153, 0.32), 0 0 14px rgba(74, 222, 128, 0.5);
+}
+
+.dark .life-week--empty {
+  background-color: rgba(148, 163, 184, 0.22);
+  border-color: rgba(148, 163, 184, 0.35);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     "./app/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}"


### PR DESCRIPTION
## Summary
- replace the previous multi-section layout with a single-screen, step-by-step onboarding that fades between year, month, day, prep, and visualization states
- animate the "Priprav sa" transition, slow green week filling, and reveal of life statistics only after the grid finishes animating, while keeping the experience scroll-free
- add a dark mode toggle, Tailwind class-based dark mode support, and refreshed styles for the week grid in both themes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d56b7ad0cc8320a4c6bdf0d321e914