### PR TITLE
Render life view immediately and drop expectancy slider

### DIFF
--- a/app/LifeClockApp.tsx
+++ b/app/LifeClockApp.tsx
@@ -127,8 +127,8 @@ export default function LifeClockApp() {
   const [dobYear, setDobYear] = useState<number>(1999)
   const [dobMonth, setDobMonth] = useState<number>(1)
   const [dobDay, setDobDay] = useState<number>(1)
-  const [dobStr, setDobStr] = useState<string>('')
-  const [expYears, setExpYears] = useState<number>(82)
+
+  const expYears = 82
 
   const years = useMemo(() => {
     const out: number[] = []
@@ -141,22 +141,16 @@ export default function LifeClockApp() {
 
   useEffect(() => {
     const maxDay = daysInMonth(dobYear, dobMonth)
-    const safeDay = Math.min(dobDay, maxDay)
-    if (safeDay !== dobDay) {
-      setDobDay(safeDay)
-      return
+    if (dobDay > maxDay) {
+      setDobDay(maxDay)
     }
-    const mm = String(dobMonth).padStart(2, '0')
-    const dd = String(safeDay).padStart(2, '0')
-    const nextDob = `${dobYear}-${mm}-${dd}`
-    setDobStr(prev => (prev === nextDob ? prev : nextDob))
   }, [dobYear, dobMonth, dobDay])
 
   useEffect(() => {
     runSelfTests()
   }, [])
 
-  const [currentStep, setCurrentStep] = useState<Step>('year')
+  const [currentStep, setCurrentStep] = useState<Step>('visual')
   const [isLeaving, setIsLeaving] = useState(false)
   const [nextStep, setNextStep] = useState<Step | null>(null)
   const [enterPhase, setEnterPhase] = useState(false)
@@ -226,8 +220,15 @@ export default function LifeClockApp() {
     }
   }, [])
 
+  const dobStr = useMemo(() => {
+    const maxDay = daysInMonth(dobYear, dobMonth)
+    const safeDay = Math.min(dobDay, maxDay)
+    const mm = String(dobMonth).padStart(2, '0')
+    const dd = String(safeDay).padStart(2, '0')
+    return `${dobYear}-${mm}-${dd}`
+  }, [dobYear, dobMonth, dobDay])
+
   const stats: LifeStats | null = useMemo(() => {
-    if (!dobStr) return null
     const dobDate = new Date(dobStr)
     if (Number.isNaN(dobDate.getTime())) return null
     return computeLifeStats(dobDate, now, expYears)
@@ -375,20 +376,9 @@ export default function LifeClockApp() {
 
         <div className={`w-full max-w-4xl transition-all duration-700 ease-out ${showDetails ? 'opacity-100 translate-y-0' : 'pointer-events-none opacity-0 translate-y-3'} lg:max-w-sm lg:self-stretch lg:pt-6`}>
           <div className="flex h-full flex-col gap-6 rounded-[28px] border border-emerald-500/15 bg-white/70 p-6 shadow-2xl backdrop-blur-xl dark:border-emerald-400/15 dark:bg-slate-900/60 sm:p-8">
-            <div className="flex flex-col gap-3 text-left sm:flex-row sm:items-center sm:justify-between">
-              <label className="text-sm font-medium text-slate-600 dark:text-slate-300">
-                Očakávaná dĺžka života:{' '}
-                <span className="font-semibold text-emerald-600 dark:text-emerald-300">{expYears.toFixed(0)} rokov</span>
-              </label>
-              <input
-                type="range"
-                min={30}
-                max={120}
-                step={1}
-                value={expYears}
-                onChange={(e) => setExpYears(clamp(Number(e.target.value), 30, 120))}
-                className="h-2 w-full max-w-sm cursor-pointer appearance-none rounded-full bg-emerald-200/60 accent-emerald-500 dark:bg-emerald-500/30"
-              />
+            <div className="flex flex-col gap-1 text-left">
+              <span className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-700 dark:text-emerald-200">Očakávaná dĺžka života</span>
+              <span className="text-lg font-semibold text-emerald-600 dark:text-emerald-300">{expYears.toFixed(0)} rokov</span>
             </div>
 
             <div className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2">


### PR DESCRIPTION
## Summary
- derive the birth date string immediately from the selected year, month, and day so the visual stage renders on first paint
- start the app in the visual stage by default and keep the expectancy at its default value
- replace the expectancy range slider with a static readout in the sidebar

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d59e5abf2c83209b7befa533fe3ed6